### PR TITLE
Support redirect for נייע אשכול notifications using Alt+M

### DIFF
--- a/extension/js/keyboardShortcuts.js
+++ b/extension/js/keyboardShortcuts.js
@@ -33,12 +33,14 @@ function toggleNotification() {
 }
 
 function nextNotification() {
-	Array.from(document.querySelectorAll("li.bg2 .notification-block")).some(node => {
-		if (node.querySelector('strong').innerText === 'תגובה') {
-            window.location.href = node.dataset.realUrl;
-			return true;
-		}
-	});
+  const nodes = document.querySelectorAll("li.bg2 .notification-block");
+  for (const node of nodes) {
+    const url = node.dataset.realUrl || node.href;
+    if (url) {
+      window.location.href = url;
+      break;
+    }
+  }
 }
 
 function checkKey(e) {


### PR DESCRIPTION
The `nextNotification` function only redirected for תגובה notifications because it gated on the `<strong>` text and assumed a single link pattern. As a result, נייע אשכול (new topic) notifications and any others with different wording or attributes were ignored.

This PR:

* Removes the type check so any `.notification-block` works.
* Redirects using `data-real-url` when present, falling back to `href`.

**Before**

```js
function nextNotification() {
  Array.from(document.querySelectorAll("li.bg2 .notification-block")).some(node => {
    if (node.querySelector('strong').innerText === 'תגובה') {
      window.location.href = node.dataset.realUrl;
      return true;
    }
  });
}
```

**After**

```js
function nextNotification() {
  const nodes = document.querySelectorAll("li.bg2 .notification-block");
  for (const node of nodes) {
    const url = node.dataset.realUrl || node.href;
    if (url) {
      window.location.href = url;
      break;
    }
  }
}
```

**Relevant HTML structure differences**

*reply notification (simpler, no forum, no data-real-url, single link)*

```html
<li class="">
  <a class="notification-block" href="./viewtopic.php?p=6234995#p6234995">
    <img ...>
    <div class="notification_text">
      <p class="notification-title"><strong>תגובה</strong> ...</p>
      <p class="notification-reference">...</p>
      <p class="notification-time">...</p>
    </div>
  </a>
</li>
```

*new topic notification (bg2 row, data-real-url on the anchor, extra forum line, separate mark-as-read link)*

```html
<li class=" bg2">
  <a class="notification-block"
     href="./index.php?mark_notification=27333046&amp;hash=8a388e2a"
     data-real-url="./viewtopic.php?t=78171">
    <img ...>
    <div class="notification_text">
      <p class="notification-title"><strong>נייע אשכול</strong> ...</p>
      <p class="notification-reference">...</p>
      <p class="notification-forum"><em>פארום:</em> ...</p>
      <p class="notification-time">...</p>
    </div>
  </a>
  <a href="./index.php?mark_notification=27333046&amp;hash=8a388e2a"
     class="mark_read icon-mark"
     data-ajax="notification.mark_read">
    <i class="icon fa-check-circle icon-xl fa-fw"></i>
    <span class="sr-only">...</span>
  </a>
</li>
```

**Key diffs**

* `<li>` class: `""` vs `" bg2"`.
* Anchor count: 1 vs 2 (second is mark-as-read).
* Primary anchor attributes: `href` only vs `href` + `data-real-url`.
* Content lines: reply lacks `notification-forum`; new topic includes it.

**Why it failed**

* The gate `strong.innerText === 'תגובה'` excluded נייע אשכול.
* Redirect relied solely on `dataset.realUrl`, which does not exist on the reply variant.

**Testing notes**

* Verify redirect on both structures.
* Confirm fallback to `href` when `data-real-url` is absent.
* Ensure mark-as-read anchor is ignored.
